### PR TITLE
Updated Current Project Repository to hold a Project instance

### DIFF
--- a/src/main/java/b_application_business_rules/use_cases/CurrentProjectRepository.java
+++ b/src/main/java/b_application_business_rules/use_cases/CurrentProjectRepository.java
@@ -3,17 +3,16 @@ package b_application_business_rules.use_cases;
 import a_enterprise_business_rules.entities.Project;
 import b_application_business_rules.entity_models.ProjectModel;
 
-import java.util.UUID;
 
 public class CurrentProjectRepository {
     /** The single instance of this singleton class */
     private static final CurrentProjectRepository currentProjectRepository = new CurrentProjectRepository(null);
 
     /** The current project that this repository is holding */
-    private ProjectModel currentProject;
+    private Project currentProject;
 
     /** Constructor for the singleton class */
-    public CurrentProjectRepository(ProjectModel currentProject) {
+    public CurrentProjectRepository(Project currentProject) {
         this.currentProject = currentProject;
     }
 
@@ -23,12 +22,12 @@ public class CurrentProjectRepository {
     }
 
     /** Gets the project that the repository holds */
-    public ProjectModel getCurrentProject() {
+    public Project getCurrentProject() {
         return currentProject;
     }
 
     /** Sets the project that the repository holds */
-    public void setCurrentProject(ProjectModel project) {
+    public void setCurrentProject(Project project) {
         currentProject = project;
     }
 
@@ -37,9 +36,4 @@ public class CurrentProjectRepository {
         this.setCurrentProject(null);
     }
 
-    public void deleteProject(UUID projectID) {}
-
-    public Project getProjectByID(UUID projectID) {
-        return null;
-    }
 }

--- a/src/main/java/b_application_business_rules/use_cases/project_selection_use_cases/ProjectSelectionInteractor.java
+++ b/src/main/java/b_application_business_rules/use_cases/project_selection_use_cases/ProjectSelectionInteractor.java
@@ -70,7 +70,7 @@ public class ProjectSelectionInteractor implements ProjectSelectionInputBoundary
 	 * @param project The project selected by the user.
 	 */
 	public void setCurrentProject(ProjectModel project) {
-		currentProjectRepository.setCurrentProject(project);
+		currentProjectRepository.setCurrentProject(project.getProjectEntity());
 	}
 
 	/**

--- a/src/main/java/b_application_business_rules/use_cases/project_viewing_and_modification_use_cases/AddTask.java
+++ b/src/main/java/b_application_business_rules/use_cases/project_viewing_and_modification_use_cases/AddTask.java
@@ -3,9 +3,6 @@ package b_application_business_rules.use_cases.project_viewing_and_modification_
 import a_enterprise_business_rules.entities.*;
 
 import b_application_business_rules.entity_models.TaskModel;
-import b_application_business_rules.use_cases.CurrentProjectRepository;
-import b_application_business_rules.use_cases.project_selection_gateways.IDBInsert;
-import d_frameworks_and_drivers.database_management.DBControllers.DBManagerInsertController;
 
 import java.util.List;
 import java.util.UUID;

--- a/src/main/java/b_application_business_rules/use_cases/project_viewing_and_modification_use_cases/ProjectViewingAndModificationInteractor.java
+++ b/src/main/java/b_application_business_rules/use_cases/project_viewing_and_modification_use_cases/ProjectViewingAndModificationInteractor.java
@@ -39,7 +39,7 @@ public class ProjectViewingAndModificationInteractor implements ProjectViewingAn
     CurrentProjectRepository currentProjectRepository = CurrentProjectRepository.getCurrentprojectrepository();
 
     // currentProject attribute to be replaced by actual project access (to access a project entity)
-    private final Project currentProject = new Project("p", UUID.randomUUID(), "", new ArrayList<Column>());
+    private final Project currentProject = CurrentProjectRepository.getCurrentprojectrepository().getCurrentProject();
 
     // The presenter holds the reference to the
     // ProjectViewingAndModificationOutputBoundary instance,

--- a/src/main/java/d_frameworks_and_drivers/database_management/DBControllers/DBManagerInsertController.java
+++ b/src/main/java/d_frameworks_and_drivers/database_management/DBControllers/DBManagerInsertController.java
@@ -9,7 +9,6 @@ import b_application_business_rules.use_cases.project_selection_gateways.IDBInse
 
 import com.opencsv.CSVReader;
 import com.opencsv.CSVWriter;
-import com.sun.glass.ui.Clipboard;
 
 
 import java.io.*;
@@ -88,7 +87,7 @@ public class DBManagerInsertController implements IDBInsert {
         data.add(columnModel.getID().toString());
         data.add(columnModel.getName());
         data.add(entityIDsToListController.EntityIDsToList(columnModel));
-        data.add(CurrentProjectRepository.getCurrentprojectrepository().getCurrentProject().getID().toString());
+//        data.add(CurrentProjectRepository.getCurrentprojectrepository().getCurrentProject().getID().toString());
 
         content.add(data.toArray(new String[0]));
 


### PR DESCRIPTION
Refactored currentProjectRepository to hold an instance of a Project Entity instead of Project Model.
This PR is to support Wendy's significant refactoring.
That PR ensures that entities are manipulated as opposed to models during use cases.

Changes are also done to classes that directly interact with currentProjectRepository to cater to new changes.